### PR TITLE
Fix typo: Use -std flag not --std

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ fi
 
 
 #if test -z $CXXFLAGS; then
-#    CXXFLAGS='-O2 --std=c++0x -fPIC -fwrapv -fno-delete-null-pointer-checks -funsigned-char -fno-strict-aliasing -Wno-pmf-conversions'
+#    CXXFLAGS='-O2 -std=c++0x -fPIC -fwrapv -fno-delete-null-pointer-checks -funsigned-char -fno-strict-aliasing -Wno-pmf-conversions'
 #fi
 
 #AC_SUBST(OBJECTS)

--- a/libxavna/Makefile.am
+++ b/libxavna/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I../include -O2 --std=c++0x -fPIC -fwrapv -fno-delete-null-pointer-checks -funsigned-char -fno-strict-aliasing -Wno-pmf-conversions
+AM_CPPFLAGS = -I../include -O2 -std=c++0x -fPIC -fwrapv -fno-delete-null-pointer-checks -funsigned-char -fno-strict-aliasing -Wno-pmf-conversions
 AM_LDFLAGS = -no-undefined
 lib_LTLIBRARIES = libxavna.la
 libxavna_la_SOURCES = xavna.C xavna_cpp.C calibration.C

--- a/libxavna/xavna_mock_ui/xavna_mock_ui.pro
+++ b/libxavna/xavna_mock_ui/xavna_mock_ui.pro
@@ -7,7 +7,7 @@
 QT       += widgets
 CONFIG += shared
 
-QMAKE_CXXFLAGS += -Wextra --std=c++11 -I/usr/local/include -I../../include
+QMAKE_CXXFLAGS += -Wextra -std=c++11 -I/usr/local/include -I../../include
 QMAKE_CXXFLAGS += -DEIGEN_DONT_VECTORIZE -DEIGEN_DISABLE_UNALIGNED_ARRAY_ASSERT
 android: QMAKE_CXXFLAGS += -DANDROID_WORKAROUNDS
 

--- a/vna_gtk/configure.ac
+++ b/vna_gtk/configure.ac
@@ -1,7 +1,7 @@
 AC_INIT(vna, version-0.1, private0x01@gmail.com)
 
 if test -z $CXXFLAGS; then
-    CXXFLAGS='-O2 --std=c++0x -fPIC -fwrapv -fno-delete-null-pointer-checks -funsigned-char -fno-strict-aliasing -Wno-pmf-conversions'
+    CXXFLAGS='-O2 -std=c++0x -fPIC -fwrapv -fno-delete-null-pointer-checks -funsigned-char -fno-strict-aliasing -Wno-pmf-conversions'
 fi
 
 AC_PROG_CXX

--- a/vna_qt/vna_qt.pro
+++ b/vna_qt/vna_qt.pro
@@ -18,7 +18,7 @@ QTPLUGIN.imageformats += svg
 
 #QMAKE_LFLAGS += --static -lexpat -lz -lXext -lXau -lbsd -lXdmcp
 #QMAKE_LFLAGS += -L../lib -lxavna
-QMAKE_CXXFLAGS += -Wextra --std=c++11
+QMAKE_CXXFLAGS += -Wextra -std=c++11
 QMAKE_CXXFLAGS += -DEIGEN_DONT_VECTORIZE -DEIGEN_DISABLE_UNALIGNED_ARRAY_ASSERT
 android: QMAKE_CXXFLAGS += -I../android_include -DANDROID_WORKAROUNDS
 


### PR DESCRIPTION
This fixes a typo in several places in the source: the flag is `-std`, not `--std`.