### PR TITLE
Add missing include file

### DIFF
--- a/libxavna/xavna_mock_ui/xavna_mock_ui.H
+++ b/libxavna/xavna_mock_ui/xavna_mock_ui.H
@@ -2,6 +2,8 @@
 #define XAVNA_MOCK_UI_H
 
 #include <functional>
+#include <string>
+
 using namespace std;
 typedef function<void(string dut_name, double cableLen1, double cableLen2)> xavna_ui_changed_cb;
 


### PR DESCRIPTION
I'm seeing a build error on Fedora 32. This fixes it.