### PR TITLE
Don't crash when bad firmware file is given

### DIFF
--- a/vna_qt/mainwindow.C
+++ b/vna_qt/mainwindow.C
@@ -276,7 +276,11 @@ void MainWindow::openDevice(string dev) {
                         tr("Open binary file"), "",
                         tr("Raw binary file *.bin (*.bin);;All Files (*)"));
                 if (fileName.isEmpty()) return;
-                updateFirmware(dev, fileName.toStdString());
+		try {
+                    updateFirmware(dev, fileName.toStdString());
+                } catch(exception& ex) {
+                    QMessageBox::critical(this,"Exception",ex.what());
+		}
             }
         } else {
             QMessageBox::critical(this,"Exception",ex.what());


### PR DESCRIPTION
Catch the exception from updateFirmware and display an
error message.